### PR TITLE
Add flymake-coffee to list of required packages

### DIFF
--- a/modules/03-packages.el
+++ b/modules/03-packages.el
@@ -11,7 +11,7 @@
 
 (let ((needed-packages
        (delq nil (mapcar (lambda (p) (when (not (package-installed-p p)) p))
-                         '(ac-geiser ac-js2 ac-nrepl ac-slime ace-jump-mode ack-and-a-half auto-complete caml cider clojure-mode clojurescript-mode coffee-mode color-theme dash diminish elisp-slime-nav epl expand-region find-file-in-project flymake-cursor flymake-easy flymake-ruby fringe-helper geiser git-commit-mode git-rebase-mode go-mode haml-mode haskell-mode highlight ido-ubiquitous inf-ruby js2-mode js2-refactor json-mode magit markdown-mode motion-mode multiple-cursors nrepl-eval-sexp-fu paredit parenface-plus pkg-info popup powerline pretty-symbols processing-mode rainbow-mode restclient robe s simple-httpd skewer-mode slime slime-repl slime-ritz smartparens smex tuareg undo-tree visual-regexp yaml-mode yasnippet)))))
+                         '(ac-geiser ac-js2 ac-nrepl ac-slime ace-jump-mode ack-and-a-half auto-complete caml cider clojure-mode clojurescript-mode coffee-mode color-theme dash diminish elisp-slime-nav epl expand-region find-file-in-project flymake-coffee flymake-cursor flymake-easy flymake-ruby fringe-helper geiser git-commit-mode git-rebase-mode go-mode haml-mode haskell-mode highlight ido-ubiquitous inf-ruby js2-mode js2-refactor json-mode magit markdown-mode motion-mode multiple-cursors nrepl-eval-sexp-fu paredit parenface-plus pkg-info popup powerline pretty-symbols processing-mode rainbow-mode restclient robe s simple-httpd skewer-mode slime slime-repl slime-ritz smartparens smex tuareg undo-tree visual-regexp yaml-mode yasnippet)))))
   (when needed-packages
     (message "Refreshing the package database...")
     (package-refresh-contents)


### PR DESCRIPTION
The `flymake-coffee` package is required in `06-prog-modes.el` at line 319 but was missing from the list of packages in `03-packages.el`
