### PR TITLE
Escape double quotes

### DIFF
--- a/lisp/skewer-coffee.el
+++ b/lisp/skewer-coffee.el
@@ -2,9 +2,9 @@
 
 (defun skewer-coffee-eval (coffee-code)
   "Requests the browser to evaluate a coffeescipt string."
-  ;; XXX should escape double quote characters
   (skewer-eval (concat "CoffeeScript.eval(\""
-                       (s-replace "\n" "\\n" (s-trim coffee-code))
+                       (s-replace "\"" "\\\""
+                                  (s-replace "\n" "\\n" (s-trim coffee-code)))
                        "\");")
                #'skewer-post-minibuffer))
 


### PR DESCRIPTION
Tried `(s-replace-all '(("\n" . "\\n") ("\"" . "\\\"")) (s-trim coffee-code))` but it was giving me  "Invalid use of `\' in replacement text"
