### PR TITLE
Replace depreciated set-default-font

### DIFF
--- a/modules/08-appearance.el
+++ b/modules/08-appearance.el
@@ -27,7 +27,7 @@
                  "%b"))))
 
 ;; font and spacing
-(set-default-font "Menlo-13")
+(set-frame-font "Menlo-13")
 (setq-default line-spacing 3)
 
 ;; unblinking bar-style cursor


### PR DESCRIPTION
`set-frame-font` appears to be the proper command as of Emacs 23