### PR TITLE
cider--turn-on-eldoc-mode is now just eldoc-mode

### DIFF
--- a/modules/06-prog-modes.el
+++ b/modules/06-prog-modes.el
@@ -193,8 +193,8 @@ Including indent-buffer, which should not be called automatically on save."
 
 (eval-after-load "cider"
   '(progn
-     (add-hook 'cider-mode-hook 'cider-turn-on-eldoc-mode)
-     (add-hook 'cider-interaction-mode-hook 'cider-turn-on-eldoc-mode)
+     (add-hook 'cider-mode-hook 'eldoc-mode)
+     (add-hook 'cider-interaction-mode-hook 'eldoc-mode)
      (setq cider-repl-print-length 1000)
      (setq cider-repl-use-clojure-font-lock t)
      (setq cider-repl-pop-to-buffer-on-connect nil)))


### PR DESCRIPTION
As of CIDER 0.12.0, cider--turn-on-eldoc-mode no longer works. [Per Bozhidar](https://groups.google.com/forum/#!topic/clojure/suo83_S3Luo):

>[cider-turn-on-eldoc-mode] was deprecated a while back (and deleted recently). Use `eldoc-mode` instead in your hooks. 

Continuing with the deprecated command breaks `M-.`/`cider-find-var`.