### PR TITLE
don't call set-fontset-font if void (non OSX builds)

### DIFF
--- a/modules/08-appearance.el
+++ b/modules/08-appearance.el
@@ -31,7 +31,8 @@
 (setq-default line-spacing 3)
 
 ;; color emoji support
-(set-fontset-font t 'unicode "Apple Color Emoji" nil 'prepend)
+(if (fboundp 'set-fontset-font)
+	(set-fontset-font t 'unicode "Apple Color Emoji" nil 'prepend))
 
 ;; unblinking bar-style cursor
 (blink-cursor-mode 0)


### PR DESCRIPTION
Emacs init errors out on linux because this is cocoa-specific