### PR TITLE
Upgrade ido-ubiquitous (reluctantly) to ido-completing-read+

### DIFF
--- a/Cask
+++ b/Cask
@@ -36,7 +36,7 @@
 (depends-on "haml-mode")
 (depends-on "haskell-mode")
 (depends-on "highlight")
-(depends-on "ido-ubiquitous")
+(depends-on "ido-completing-read+")
 (depends-on "inf-ruby")
 (depends-on "js2-mode")
 (depends-on "js2-refactor")

--- a/modules/05-more-bindings.el
+++ b/modules/05-more-bindings.el
@@ -9,7 +9,8 @@
 
 ;; ido-mode is a work of beauty and magic
 (ido-mode t)
-(ido-ubiquitous t)
+(ido-everywhere t)
+(ido-ubiquitous-mode t)
 (setq ido-enable-prefix nil
       ido-enable-flex-matching t
       ido-auto-merge-work-directories-length nil


### PR DESCRIPTION
Fixes #24 but big-picture I'd like to A) divorce Cask, which helped
cause this ridiculous sideways upgrade, and B) divorce
ido-completing-read+, which seems to be trigger-happy with breaking
changes.