### PR TITLE
Only load modules with ".el" suffix, not e.g. ".el~"

### DIFF
--- a/init.el
+++ b/init.el
@@ -35,7 +35,7 @@
 
 ;;; Like /etc/rc.d, all startup filenames begin with a number and get
 ;;; loaded in numerical order.
-(mapc #'load-file (directory-files (concat user-emacs-directory "modules") t "[0-9]*.el"))
+(mapc #'load-file (directory-files (concat user-emacs-directory "modules") t "[0-9]*.el$"))
 
 ;;; PER-USER CUSTOMIZATIONS
 


### PR DESCRIPTION
Normally this is not a problem because this config moves backup files
out of the modules directory to a central location. However, in
scenarios where for whatever reason that config step has not yet been
made, module file backups' filenames end with a ".el~" and get found
by this statement, causing all sorts of odd errors.