### PR TITLE
Multiple-cursors keybindings

### DIFF
--- a/modules/05-more-bindings.el
+++ b/modules/05-more-bindings.el
@@ -61,3 +61,9 @@
 
 ;; Enable which-key for function discovery
 (which-key-mode)
+
+;; Multiple cursors magic
+(global-set-key (kbd "C-,") 'mc/edit-lines)
+(global-set-key (kbd "C->") 'mc/mark-next-like-this)
+(global-set-key (kbd "C-<") 'mc/mark-previous-like-this)
+(global-set-key (kbd "C-c C-<") 'mc/mark-all-like-this)


### PR DESCRIPTION
Adds [orthodox keybindings](https://github.com/magnars/multiple-cursors.el#basic-usage) (`C-,`, `C->`, `C-<`, `C-c C-<`) for multiple-cursors mode.