### PR TITLE
Emacs 27.1 compatibility

### DIFF
--- a/eigengrau/eigengrau-definitions.el
+++ b/eigengrau/eigengrau-definitions.el
@@ -1,5 +1,5 @@
 (eval-when-compile
-  (require 'cl))
+  (require 'cl-lib))
 
 (defconst eigengrau-description
   "A dark color theme based on Solarized's definitions as implemented by Noctilux.")

--- a/eigengrau/eigengrau-theme.el
+++ b/eigengrau/eigengrau-theme.el
@@ -1,3 +1,4 @@
+(setq custom--inhibit-theme-enable nil)
 (require 'eigengrau-definitions
          (locate-file "eigengrau-definitions.el" custom-theme-load-path
                       '("c" "")))

--- a/init.el
+++ b/init.el
@@ -8,7 +8,7 @@
 (add-to-list 'package-archives
              '("melpa" . "https://melpa.org/packages/")
              '("org" . "http://orgmode.org/elpa/"))
-(package-initialize)
+(when (version< emacs-version "27.0") (package-initialize))
 
 (custom-set-variables
  ;; custom-set-variables was added by Custom.

--- a/modules/01-packages.el
+++ b/modules/01-packages.el
@@ -8,7 +8,7 @@
 
 
 ;;;; We need the `use-package` package before we use `use-package` to use all our packages
-(package-initialize)
+(when (version< emacs-version "27.0") (package-initialize))
 
 (unless (file-exists-p (expand-file-name "archives/melpa" package-user-dir))
   (package-refresh-contents))

--- a/modules/06-prog-modes.el
+++ b/modules/06-prog-modes.el
@@ -180,7 +180,7 @@ Including indent-buffer, which should not be called automatically on save."
              (define-key geiser-mode-map (kbd "C-c d") 'geiser-doc-symbol-at-point)
              (define-key geiser-mode-map (kbd "<s-return>") 'geiser-eval-last-sexp)
              (define-key geiser-mode-map (kbd "<S-s-return>") 'geiser-eval-definition)
-             (define-key geiser-mode-map (kbd "<S-s-return>") 'geiser-eval-buffer)))
+             (define-key geiser-mode-map (kbd "<C-S-s-return>") 'geiser-eval-buffer)))
 
 ;;; XXX COMMON LISP moved to private config for the moment
 


### PR DESCRIPTION
* only call `package-initialize` on older Emacs versions
* set `custom--inhibit-theme-enable` to enable eigengrau to load
* switch eigengrau from 'cl to 'cl-lib
* bonus: Fix keybinding for `geiser-eval-buffer`to not override `geiser-eval-definition`

I also unpinned `org` and `cider` in my config so they would not call `package-initialize` anymore but not sure you want that upstream. Another local change I made was remove `pallet` which would give me an installation error.