### PR TITLE
Remove --with-xml2 from install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ YAMAMOTO Mitsuharu's Mac port, also called the _railwaycat_ version,
 which I install using [homebrew](http://brew.sh/).
 
 ```bash
-$ brew tap railwaycat/emacsmacport && brew install emacs-mac --with-xml2 --with-imagemagick --with-modern-icon --with-modules
+$ brew tap railwaycat/emacsmacport && brew install emacs-mac --with-imagemagick --with-modern-icon --with-modules
 ```
 
 Once this is complete, you should also install


### PR DESCRIPTION
I tried following your installation instructions on macOS 13.4, ran into:

```shell
$ brew install emacs-mac --with-xml2 --with-imagemagick --with-modern-icon --with-modules
...
Error: invalid option: --with-xml2
```

It looks like the option was [changed](https://bitbucket.org/mituharu/emacs-mac/src/7ec68b6ffd2d5cfdc659c64d83b1e0f613a76b4a/nt/INSTALL#lines-779:781):

>  If the configure script finds the libxml2 header files and libraries
>  on your system, Emacs is built with libxml2 support by default; to
>  avoid that you can pass the argument --without-libxml2.

And after removing `--with-xml2` the homebrew logs still show `./configure` detecting it, so I assume all is well.

```
checking for libxml-2.0 > 2.6.17... yes
checking for htmlReadMemory in -lxml2... yes
```