### PR TITLE
Remove git-commit

### DIFF
--- a/modules/01-packages.el
+++ b/modules/01-packages.el
@@ -59,7 +59,6 @@
 (use-package flymake-ruby)
 (use-package fringe-helper)
 (use-package geiser)
-(use-package git-commit)
 (use-package go-mode)
 (use-package haml-mode)
 (use-package haskell-mode)


### PR DESCRIPTION
>Since Magit v4.1.0, git-commit.el is no longer distributed as a separate package git-commit. It is now part of the magit package.

per https://github.com/nonsequitur/git-gutter-plus/issues/48